### PR TITLE
Add meal tracking and contextual analysis

### DIFF
--- a/ai_dietolog/agents/contextual.py
+++ b/ai_dietolog/agents/contextual.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""Context analysis agent."""
+
+import json
+from openai import AsyncOpenAI
+
+from ..core.prompts import CONTEXT_ANALYSIS
+from ..core.schema import Total
+
+
+async def analyze_context(
+    profile_norms: dict,
+    day_summary: Total,
+    new_meal_total: Total,
+    cfg: dict,
+) -> dict:
+    """Return updated summary and comment for the new meal."""
+    client = AsyncOpenAI(api_key=cfg.get("openai_api_key"))
+    system = CONTEXT_ANALYSIS.render(
+        norms=json.dumps(profile_norms, ensure_ascii=False),
+        day_summary=json.dumps(day_summary.model_dump(), ensure_ascii=False),
+        new_meal=json.dumps(new_meal_total.model_dump(), ensure_ascii=False),
+    )
+    resp = await client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "system", "content": system}],
+        temperature=0.3,
+        response_format={"type": "json_object"},
+    )
+    return json.loads(resp.choices[0].message.content)

--- a/ai_dietolog/agents/intake.py
+++ b/ai_dietolog/agents/intake.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Meal intake agent."""
+
+import json
+from datetime import datetime
+from uuid import uuid4
+from typing import Optional
+
+from openai import AsyncOpenAI
+
+from ..core.prompts import MEAL_JSON
+from ..core.schema import Item, Meal, Total
+
+
+async def intake(image: Optional[bytes], user_text: str, meal_type: str) -> Meal:
+    """Analyse ``user_text`` describing a meal and return a ``Meal`` object."""
+    client = AsyncOpenAI()
+    system = MEAL_JSON.render(meal_type=meal_type, user_desc=user_text)
+    resp = await client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "system", "content": system}],
+        temperature=0,
+        response_format={"type": "json_object"},
+    )
+    data = json.loads(resp.choices[0].message.content)
+    items = [Item(**item) for item in data.get("items", [])]
+    total = Total(**data.get("total", {}))
+    meal = Meal(
+        id=str(uuid4()),
+        type=meal_type,
+        items=items,
+        total=total,
+        pending=True,
+        timestamp=datetime.utcnow(),
+        percent_eaten=100,
+    )
+    return meal

--- a/ai_dietolog/core/prompts.py
+++ b/ai_dietolog/core/prompts.py
@@ -10,3 +10,22 @@ PROFILE_TO_JSON = (
     "обновлённым JSON, соответствующим схеме Profile без лишних пояснений."
 )
 
+from jinja2 import Template
+
+# Template for meal recognition
+MEAL_JSON = Template(
+    "Ты русскоязычный ассистент-диетолог. "
+    "Тип приёма пищи: {{ meal_type }}. "
+    "Описание пользователя: {{ user_desc }}.\n"
+    "Верни JSON с ключами 'items' и 'total' без лишних пояснений."
+)
+
+# Template for contextual analysis after добавления блюда
+CONTEXT_ANALYSIS = Template(
+    "Ты анализируешь дневник питания.\n"
+    "Нормы пользователя: {{ norms }}.\n"
+    "Текущий итог дня: {{ day_summary }}.\n"
+    "Новый приём пищи: {{ new_meal }}.\n"
+    "Верни JSON с полем 'summary' (обновлённый итог) и 'context_comment'."
+)
+

--- a/ai_dietolog/core/storage.py
+++ b/ai_dietolog/core/storage.py
@@ -14,6 +14,7 @@ from typing import Any, Type, TypeVar
 
 from filelock import FileLock
 from pydantic import BaseModel
+from .schema import Today
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -125,3 +126,25 @@ def save_profile(user_id: str | int, profile: BaseModel) -> None:
         profile: Pydantic model representing the profile.
     """
     write_json(json_path(user_id, "profile.json"), profile)
+
+
+def today_path(user_id: str | int) -> Path:
+    """Return path to ``today.json`` for a user."""
+    return json_path(user_id, "today.json")
+
+
+def load_today(user_id: str | int) -> Today:
+    """Load today's meal log for ``user_id``."""
+    return read_json(today_path(user_id), Today)
+
+
+def save_today(user_id: str | int, today: Today) -> None:
+    """Persist today's data for ``user_id``."""
+    write_json(today_path(user_id), today)
+
+
+def append_meal(user_id: str | int, meal: BaseModel) -> None:
+    """Append a meal to ``today.json`` for the user."""
+    today = load_today(user_id)
+    today.append_meal(meal)
+    save_today(user_id, today)


### PR DESCRIPTION
## Summary
- store today's meals and totals
- add intake and contextual OpenAI agents
- prompt templates for meals and context analysis
- extend Telegram bot with add/confirm/edit/delete meal handlers
- allow closing the day with history logging

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887283be6a4832482e1fc4c253f4ba1