### PR TITLE
Fix missing meal description handler

### DIFF
--- a/ai_dietolog/bot/telegram_bot.py
+++ b/ai_dietolog/bot/telegram_bot.py
@@ -451,6 +451,9 @@ async def receive_meal_type(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     )
     return MEAL_DESC
 
+
+async def receive_meal_desc(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    """Process a meal description and photo sent by the user."""
     desc = update.message.caption or update.message.text or ""
     image_bytes = None
     file_id = None


### PR DESCRIPTION
## Summary
- add `receive_meal_desc` handler to process photos/text and save meals
- hook the new handler into the meal conversation flow

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688762b3c2a4832485d2137c2c3d96eb