### PR TITLE
Add language-aware prompt templates

### DIFF
--- a/ai_dietolog/agents/contextual.py
+++ b/ai_dietolog/agents/contextual.py
@@ -14,6 +14,8 @@ async def analyze_context(
     day_summary: Total,
     new_meal_total: Total,
     cfg: dict,
+    *,
+    language: str = "ru",
 ) -> dict:
     """Return updated summary and comment for the new meal."""
     client = AsyncOpenAI(api_key=cfg.get("openai_api_key"))
@@ -21,6 +23,7 @@ async def analyze_context(
         norms=json.dumps(profile_norms, ensure_ascii=False),
         day_summary=json.dumps(day_summary.model_dump(), ensure_ascii=False),
         new_meal=json.dumps(new_meal_total.model_dump(), ensure_ascii=False),
+        language=language,
     )
     resp = await client.chat.completions.create(
         model="gpt-4o",

--- a/ai_dietolog/agents/intake.py
+++ b/ai_dietolog/agents/intake.py
@@ -16,10 +16,20 @@ from ..core.prompts import MEAL_JSON
 from ..core.schema import Item, Meal, Total
 
 
-async def intake(image: Optional[bytes], user_text: str, meal_type: str) -> Meal:
+async def intake(
+    image: Optional[bytes],
+    user_text: str,
+    meal_type: str,
+    *,
+    language: str = "ru",
+) -> Meal:
     """Analyse ``user_text`` describing a meal and return a ``Meal`` object."""
     client = AsyncOpenAI()
-    system = MEAL_JSON.render(meal_type=meal_type, user_desc=user_text)
+    system = MEAL_JSON.render(
+        meal_type=meal_type,
+        user_desc=user_text,
+        language=language,
+    )
 
     messages = [{"role": "system", "content": system}]
     if image is not None:
@@ -50,18 +60,11 @@ async def intake(image: Optional[bytes], user_text: str, meal_type: str) -> Meal
     for it in items_raw:
         if "calories" in it and "kcal" not in it:
             it["kcal"] = it.pop("calories")
-        it.setdefault("protein_g", 0)
-        it.setdefault("fat_g", 0)
-        it.setdefault("carbs_g", 0)
-        it.setdefault("sugar_g", 0)
-        it.setdefault("fiber_g", 0)
         norm_items.append(it)
 
     total_raw = data.get("total", {})
     if "calories" in total_raw and "kcal" not in total_raw:
         total_raw["kcal"] = total_raw.pop("calories")
-    for key in ("protein_g", "fat_g", "carbs_g", "sugar_g", "fiber_g"):
-        total_raw.setdefault(key, 0)
 
     try:
         items = [Item(**item) for item in norm_items]

--- a/ai_dietolog/agents/profile_editor.py
+++ b/ai_dietolog/agents/profile_editor.py
@@ -12,14 +12,23 @@ from ..core.prompts import PROFILE_TO_JSON
 logger = logging.getLogger(__name__)
 
 
-async def update_profile(existing_profile: dict, user_request: str, api_key: str) -> dict:
+async def update_profile(
+    existing_profile: dict,
+    user_request: str,
+    api_key: str,
+    *,
+    language: str = "ru",
+) -> dict:
     """Merge ``user_request`` into ``existing_profile`` using GPT-4o.
 
     The language model receives the current profile JSON and should return
     only an updated JSON object. The returned value is parsed and returned
     as a Python ``dict``.
     """
-    system = PROFILE_TO_JSON.format(profile=json.dumps(existing_profile, ensure_ascii=False))
+    system = PROFILE_TO_JSON.render(
+        profile=json.dumps(existing_profile, ensure_ascii=False),
+        language=language,
+    )
     client = AsyncOpenAI(api_key=api_key)
     resp = await client.chat.completions.create(
         model="gpt-4o",

--- a/ai_dietolog/core/prompts.py
+++ b/ai_dietolog/core/prompts.py
@@ -2,37 +2,37 @@ from __future__ import annotations
 
 """Prompt templates for OpenAI requests."""
 
-PROFILE_TO_JSON = (
-    "Ты русскоязычный ассистент-диетолог. "
-    "Ниже указан текущий профиль пользователя в формате JSON.\n"
-    "{profile}\n\n"
-    "Обнови этот профиль согласно запросу пользователя и ответь ТОЛЬКО\n"
-    "обновлённым JSON, соответствующим схеме Profile без лишних пояснений."
-)
-
 from jinja2 import Template
+
+# Prompt for profile editing
+PROFILE_TO_JSON = Template(
+    "You are a nutrition assistant.\n"
+    "Below is the user's current profile JSON:\n"
+    "{{ profile }}\n\n"
+    "Update this profile according to the user's request and reply ONLY with\n"
+    "the updated JSON that matches the Profile schema without any extra\n"
+    "explanations. Any human-readable text must be in {{ language }}."
+)
 
 # Template for meal recognition
 MEAL_JSON = Template(
-    "Ты русскоязычный ассистент-диетолог. "
-    "Тип приёма пищи: {{ meal_type }}. "
-    "Описание пользователя: {{ user_desc }}.\n"
-    "Учитывай любые дополнительные комментарии при распознавании блюда. "
-    "Используй прикреплённое изображение и текст для разбора блюда. "
-    "Не делай предположений о типичных продуктах только по типу приёма пищи. "
-    "Верни JSON с ключами 'items' и 'total' без лишних пояснений. "
-    "Каждый объект в 'items' ОБЯЗАТЕЛЬНО должен содержать поля "
-    "name, weight_g (если известно), kcal, protein_g, fat_g, "
-    "carbs_g, sugar_g и fiber_g. Итог 'total' использует те же ключи. "
-    "Не используй ключ 'calories' – только 'kcal'. Если какие-либо значения "
-    "неизвестны, указывай 0."
+    "You are a nutrition assistant. Meal type: {{ meal_type }}.\n"
+    "User description: {{ user_desc }}. Use the attached image and text to\n"
+    "identify all food items. Do not guess typical foods based only on the\n"
+    "meal type. Estimate weight in grams and macronutrients if not provided.\n"
+    "Return JSON with keys 'items' and 'total' only. Each element in 'items'\n"
+    "and the 'total' object MUST contain the keys name, weight_g, kcal,\n"
+    "protein_g, fat_g, carbs_g, sugar_g and fiber_g. Use the key 'kcal' and\n"
+    "never 'calories'. Any item names or other human-readable text must be in\n"
+    "{{ language }}."
 )
 
 # Template for contextual analysis after добавления блюда
 CONTEXT_ANALYSIS = Template(
-    "Ты анализируешь дневник питания.\n"
-    "Нормы пользователя: {{ norms }}.\n"
-    "Текущий итог дня: {{ day_summary }}.\n"
-    "Новый приём пищи: {{ new_meal }}.\n"
-    "Верни JSON с полем 'summary' (обновлённый итог) и 'context_comment'."
+    "You analyse the food diary.\n"
+    "User norms: {{ norms }}.\n"
+    "Current day summary: {{ day_summary }}.\n"
+    "New meal: {{ new_meal }}.\n"
+    "Return JSON with 'summary' (updated totals) and 'context_comment'. The\n"
+    "comment must be in {{ language }}."
 )

--- a/ai_dietolog/core/schema.py
+++ b/ai_dietolog/core/schema.py
@@ -16,11 +16,11 @@ class Item(BaseModel):
     name: str
     weight_g: Optional[int] = None
     kcal: int
-    protein_g: int = 0
-    fat_g: int = 0
-    carbs_g: int = 0
-    sugar_g: Optional[int] = 0
-    fiber_g: Optional[int] = 0
+    protein_g: Optional[int] = None
+    fat_g: Optional[int] = None
+    carbs_g: Optional[int] = None
+    sugar_g: Optional[int] = None
+    fiber_g: Optional[int] = None
 
     def scale(self, factor: float) -> "Item":
         """Return a new ``Item`` scaled by the given factor.


### PR DESCRIPTION
## Summary
- internationalise meal and context analysis prompts
- include language parameter in profile editing prompt
- store user language at conversation start
- pass language to OpenAI calls
- allow missing macros in meal items

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68876b6d65808324bcff717f521b5f51