### PR TITLE
Add conversation memory

### DIFF
--- a/ai_dietolog/agents/contextual.py
+++ b/ai_dietolog/agents/contextual.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Context analysis agent."""
 
 import json
+from typing import Optional
 from openai import AsyncOpenAI
 
 from ..core.prompts import CONTEXT_ANALYSIS
@@ -16,6 +17,7 @@ async def analyze_context(
     cfg: dict,
     *,
     language: str = "ru",
+    history: Optional[list[str]] = None,
 ) -> dict:
     """Return updated summary and comment for the new meal."""
     client = AsyncOpenAI(api_key=cfg.get("openai_api_key"))
@@ -25,9 +27,22 @@ async def analyze_context(
         new_meal=json.dumps(new_meal_total.model_dump(), ensure_ascii=False),
         language=language,
     )
+    messages = []
+    if history:
+        hist_text = "\n".join(history[-20:])
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "Previous conversation with the user (for context only, do not answer these):\n"
+                    f"{hist_text}\n--- End of previous messages ---"
+                ),
+            }
+        )
+    messages.append({"role": "system", "content": system})
     resp = await client.chat.completions.create(
         model="gpt-4o",
-        messages=[{"role": "system", "content": system}],
+        messages=messages,
         temperature=0.3,
         response_format={"type": "json_object"},
     )

--- a/ai_dietolog/agents/intake.py
+++ b/ai_dietolog/agents/intake.py
@@ -22,6 +22,7 @@ async def intake(
     meal_type: str,
     *,
     language: str = "ru",
+    history: Optional[list[str]] = None,
 ) -> Meal:
     """Analyse ``user_text`` describing a meal and return a ``Meal`` object."""
     client = AsyncOpenAI()
@@ -31,7 +32,19 @@ async def intake(
         language=language,
     )
 
-    messages = [{"role": "system", "content": system}]
+    messages = []
+    if history:
+        hist_text = "\n".join(history[-20:])
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "Previous conversation with the user (for context only, do not answer these):\n"
+                    f"{hist_text}\n--- End of previous messages ---"
+                ),
+            }
+        )
+    messages.append({"role": "system", "content": system})
     if image is not None:
         b64 = base64.b64encode(image).decode()
         image_url = f"data:image/jpeg;base64,{b64}"


### PR DESCRIPTION
## Summary
- keep last 20 user messages in `context.user_data['history']`
- prepend conversation history to system prompts in `intake` and `analyze_context`
- pass stored history to GPT agents during meal logging

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887724e199083248c897690602a6ac5