### PR TITLE
Handle fractional macros in intake

### DIFF
--- a/ai_dietolog/agents/intake.py
+++ b/ai_dietolog/agents/intake.py
@@ -79,6 +79,30 @@ async def intake(
     if "calories" in total_raw and "kcal" not in total_raw:
         total_raw["kcal"] = total_raw.pop("calories")
 
+    for item in norm_items:
+        for key in [
+            "kcal",
+            "protein_g",
+            "fat_g",
+            "carbs_g",
+            "sugar_g",
+            "fiber_g",
+        ]:
+            val = item.get(key)
+            if isinstance(val, float):
+                item[key] = int(round(val))
+    for key in [
+        "kcal",
+        "protein_g",
+        "fat_g",
+        "carbs_g",
+        "sugar_g",
+        "fiber_g",
+    ]:
+        val = total_raw.get(key)
+        if isinstance(val, float):
+            total_raw[key] = int(round(val))
+
     try:
         items = [Item(**item) for item in norm_items]
         total = Total(**total_raw)

--- a/ai_dietolog/tests/test_intake_rounding.py
+++ b/ai_dietolog/tests/test_intake_rounding.py
@@ -1,0 +1,44 @@
+import asyncio
+import json
+
+from ai_dietolog.agents import intake as intake_module
+
+
+def test_fractional_macros_rounding(monkeypatch):
+    meal_resp = {
+        "items": [
+            {"name": "apple", "kcal": 50.5, "protein_g": 0.4, "fat_g": 0.5},
+        ],
+        "total": {"kcal": 50.5, "protein_g": 0.4, "fat_g": 0.5},
+    }
+    meal_json = json.dumps(meal_resp)
+
+    async def fake_create(*args, **kwargs):
+        class Message:
+            def __init__(self, content):
+                self.content = meal_json
+
+        class Choice:
+            def __init__(self):
+                self.message = Message(meal_json)
+
+        class Resp:
+            def __init__(self):
+                self.choices = [Choice()]
+
+        return Resp()
+
+    class FakeClient:
+        def __init__(self):
+            self.chat = type("Chat", (), {"completions": type("Comp", (), {"create": fake_create})()})()
+
+    monkeypatch.setattr(intake_module, "AsyncOpenAI", lambda: FakeClient())
+
+    meal = asyncio.run(intake_module.intake(image=None, user_text="apple", meal_type="breakfast"))
+
+    assert meal.items[0].kcal == int(round(50.5))
+    assert meal.items[0].protein_g == int(round(0.4))
+    assert meal.items[0].fat_g == int(round(0.5))
+    assert meal.total.kcal == int(round(50.5))
+    assert meal.total.protein_g == int(round(0.4))
+    assert meal.total.fat_g == int(round(0.5))


### PR DESCRIPTION
## Summary
- round float macro values returned from GPT in `intake`
- add regression test to ensure fractional macros parse without errors

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887763b6bec8324b27c45f7f98e1167