### PR TITLE
Enhance meal history details

### DIFF
--- a/ai_dietolog/core/schema.py
+++ b/ai_dietolog/core/schema.py
@@ -129,8 +129,10 @@ class History(BaseModel):
 
 
 class MealBrief(BaseModel):
-    """Simplified nutritional info for one meal."""
+    """Simplified information about one meal for history."""
 
+    type: str = ""
+    name: str = ""
     kcal: int = 0
     protein_g: int = 0
     fat_g: int = 0


### PR DESCRIPTION
## Summary
- include meal `type` and `name` in `MealBrief`
- record these fields when closing a day
- generate up to five daily summary comments and warn about fibre and sugar

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887b435e290832498c3f652c2c3c52e