### PR TITLE
Store AI meal comments

### DIFF
--- a/ai_dietolog/bot/telegram_bot.py
+++ b/ai_dietolog/bot/telegram_bot.py
@@ -560,12 +560,17 @@ async def confirm_meal(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     )
     meal.pending = False
     today.summary = Total(**result.get("summary", {}))
+    comment = result.get("context_comment")
+    if comment:
+        meal.comment = f"{meal.comment or ''} {comment}".strip()
+        history = context.user_data.setdefault("history", [])
+        history.append(comment)
+        del history[:-20]
     storage.save_today(update.effective_user.id, today)
     if query.message.photo:
         await query.message.edit_caption(meal_card(meal))
     else:
         await query.message.edit_text(meal_card(meal))
-    comment = result.get("context_comment")
     stats = format_stats(profile.norms, today.summary, comment)
     await query.message.reply_text(stats, parse_mode="Markdown")
 


### PR DESCRIPTION
## Summary
- save AI-generated context comments with each meal
- keep limited history of comments for future context

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68886424f5e08324a3f5273e4b5dc043