### PR TITLE
Fix comment editing logic

### DIFF
--- a/ai_dietolog/bot/telegram_bot.py
+++ b/ai_dietolog/bot/telegram_bot.py
@@ -682,12 +682,11 @@ async def apply_comment(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         return ConversationHandler.END
     meal.comment = f"{meal.comment or ''} {comment}".strip()
     user_desc = f"{meal.user_desc} {comment}".strip()
-    image_bytes = None
-    if meal.image_file_id:
-        file = await context.bot.get_file(meal.image_file_id)
-        image_bytes = await file.download_as_bytearray()
+    # Do not resend the photo when refining the meal with a comment.  The
+    # comment should only adjust the textual description, so the image is not
+    # downloaded or passed to the intake agent again.
     updated = await intake(
-        image_bytes,
+        None,
         user_desc,
         meal.type,
         language=context.user_data.get("language", "ru"),

--- a/ai_dietolog/tests/test_comment_no_image.py
+++ b/ai_dietolog/tests/test_comment_no_image.py
@@ -1,0 +1,52 @@
+import asyncio
+from types import SimpleNamespace
+from datetime import datetime
+
+import ai_dietolog.bot.telegram_bot as bot
+from ai_dietolog.core.schema import Item, Meal, Total, Today
+from ai_dietolog.core import storage
+
+
+def test_apply_comment_without_image(monkeypatch):
+    meal = Meal(
+        id="1",
+        type="breakfast",
+        items=[Item(name="apple", kcal=50)],
+        total=Total(kcal=50),
+        timestamp=datetime.utcnow(),
+    )
+    meal.user_desc = "apple"
+    meal.image_file_id = "file123"
+    today = Today(meals=[meal])
+    monkeypatch.setattr(storage, "load_today", lambda uid: today)
+    monkeypatch.setattr(storage, "save_today", lambda uid, t: None)
+
+    async def fake_intake(image, user_text, meal_type, *, language="ru", history=None):
+        assert image is None
+        return meal
+
+    monkeypatch.setattr(bot, "intake", fake_intake)
+
+    class DummyBot:
+        async def get_file(self, file_id):
+            raise AssertionError("get_file should not be called")
+
+        async def edit_message_caption(self, **kwargs):
+            pass
+
+        async def edit_message_text(self, **kwargs):
+            pass
+
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        effective_chat=SimpleNamespace(id=2),
+        effective_message=SimpleNamespace(message_id=3),
+        message=SimpleNamespace(text="extra", reply_text=lambda *a, **k: None),
+    )
+    context = SimpleNamespace(
+        bot=DummyBot(),
+        user_data={"comment_meal_id": "1"},
+    )
+
+    res = asyncio.run(bot.apply_comment(update, context))
+    assert res == bot.SET_COMMENT


### PR DESCRIPTION
## Summary
- avoid reprocessing the dish image when adding a comment
- test that comments don't trigger image download

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68886f5f1dfc8324b694aa70e195a5a3