### PR TITLE
Improve meal comments

### DIFF
--- a/ai_dietolog/agents/__init__.py
+++ b/ai_dietolog/agents/__init__.py
@@ -1,6 +1,13 @@
 """Agents package initialization."""
 
-from . import daily_review, contextual, intake, profile_collector, profile_editor
+from . import (
+    daily_review,
+    contextual,
+    intake,
+    profile_collector,
+    profile_editor,
+    meal_editor,
+)
 
 __all__ = [
     "daily_review",
@@ -8,4 +15,5 @@ __all__ = [
     "intake",
     "profile_collector",
     "profile_editor",
+    "meal_editor",
 ]

--- a/ai_dietolog/agents/meal_editor.py
+++ b/ai_dietolog/agents/meal_editor.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""Agent for refining an existing meal based on a user comment."""
+
+import json
+import logging
+from typing import Optional
+
+from openai import AsyncOpenAI
+from pydantic import ValidationError
+
+from ..core.prompts import UPDATE_MEAL_JSON
+from ..core.schema import Item, Meal, Total
+
+logger = logging.getLogger(__name__)
+
+
+async def edit_meal(
+    existing_meal: Meal,
+    comment: str,
+    *,
+    language: str = "ru",
+    history: Optional[list[str]] = None,
+) -> Meal:
+    """Return an updated ``Meal`` incorporating ``comment``.
+
+    The language model receives the current meal JSON and the user comment.
+    It should return JSON with the same number of items, adjusting names or
+    nutrition if needed. If parsing fails or the number of items differs from
+    the original, the original meal object is returned.
+    """
+    system = UPDATE_MEAL_JSON.render(
+        meal=json.dumps(existing_meal.model_dump(), ensure_ascii=False),
+        comment=comment,
+        language=language,
+    )
+    client = AsyncOpenAI()
+    messages = []
+    if history:
+        hist_text = "\n".join(history[-20:])
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    "Previous conversation with the user (for context only, do not answer these):\n"
+                    f"{hist_text}\n--- End of previous messages ---"
+                ),
+            }
+        )
+    messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": comment})
+    resp = await client.chat.completions.create(
+        model="gpt-4o",
+        messages=messages,
+        temperature=0,
+        response_format={"type": "json_object"},
+    )
+    try:
+        data = json.loads(resp.choices[0].message.content)
+    except json.JSONDecodeError as exc:  # noqa: BLE001
+        logger.exception("Failed to parse meal update: %s", exc)
+        return existing_meal
+
+    items_raw = data.get("items", [])
+    total_raw = data.get("total", {})
+
+    for it in items_raw:
+        if "calories" in it and "kcal" not in it:
+            it["kcal"] = it.pop("calories")
+    if "calories" in total_raw and "kcal" not in total_raw:
+        total_raw["kcal"] = total_raw.pop("calories")
+
+    for item in items_raw:
+        for key in [
+            "kcal",
+            "protein_g",
+            "fat_g",
+            "carbs_g",
+            "sugar_g",
+            "fiber_g",
+        ]:
+            val = item.get(key)
+            if isinstance(val, float):
+                item[key] = int(round(val))
+    for key in [
+        "kcal",
+        "protein_g",
+        "fat_g",
+        "carbs_g",
+        "sugar_g",
+        "fiber_g",
+    ]:
+        val = total_raw.get(key)
+        if isinstance(val, float):
+            total_raw[key] = int(round(val))
+
+    try:
+        items = [Item(**it) for it in items_raw]
+        total = Total(**total_raw)
+    except ValidationError as exc:  # noqa: BLE001
+        logger.exception("Invalid meal update structure: %s", exc)
+        return existing_meal
+
+    if len(items) != len(existing_meal.items):
+        logger.warning("Ignoring meal update due to item count mismatch")
+        return existing_meal
+
+    return existing_meal.copy(update={
+        "items": items,
+        "total": total,
+        "clarification": data.get("clarification"),
+    })

--- a/ai_dietolog/core/prompts.py
+++ b/ai_dietolog/core/prompts.py
@@ -33,6 +33,16 @@ MEAL_JSON = Template(
     " text must be in {{ language }}."
 )
 
+# Template for refining a meal with additional comments
+UPDATE_MEAL_JSON = Template(
+    "You are a nutrition assistant.\n"
+    "Here is the current meal JSON:\n"
+    "{{ meal }}\n\n"
+    "The user added a comment: '{{ comment }}'.\n"
+    "Update the JSON to reflect this comment while keeping the same number of items.\n"
+    "Return only the updated JSON in {{ language }} without extra explanations."
+)
+
 # Template for contextual analysis after добавления блюда
 CONTEXT_ANALYSIS = Template(
     "You analyse the food diary.\n"


### PR DESCRIPTION
## Summary
- add template for updating existing meals
- implement `edit_meal` agent to refine meal JSON using comments
- use the new agent when applying meal comments so item count doesn't change
- test comment handling and new meal editor

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68887c9f05e48324ac1b63d8f2d3219f