### PR TITLE
Fix edit_meal datetime serialization

### DIFF
--- a/ai_dietolog/agents/meal_editor.py
+++ b/ai_dietolog/agents/meal_editor.py
@@ -30,7 +30,7 @@ async def edit_meal(
     the original, the original meal object is returned.
     """
     system = UPDATE_MEAL_JSON.render(
-        meal=json.dumps(existing_meal.model_dump(), ensure_ascii=False),
+        meal=json.dumps(existing_meal.model_dump(mode="json"), ensure_ascii=False),
         comment=comment,
         language=language,
     )


### PR DESCRIPTION
## Summary
- fix JSON encoding of meals when editing by using `model_dump(mode="json")`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68887f8db844832482111ecaea6e1a7d