### PR TITLE
Fix comment conversation state

### DIFF
--- a/ai_dietolog/bot/telegram_bot.py
+++ b/ai_dietolog/bot/telegram_bot.py
@@ -99,7 +99,7 @@ async def handle_button_click(
     if query.data == "edit_profile":
         return await start_edit_profile(update, context)
     await query.answer()
-    return ConversationHandler.END
+    return SET_COMMENT
 
 
 async def setup_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
@@ -733,7 +733,7 @@ async def apply_comment(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         await context.bot.edit_message_text(
             chat_id=chat_id, message_id=msg_id, text=text, reply_markup=keyboard
         )
-    return SET_COMMENT
+    return ConversationHandler.END
 
 
 async def delete_meal(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/ai_dietolog/tests/test_comment_no_image.py
+++ b/ai_dietolog/tests/test_comment_no_image.py
@@ -49,4 +49,5 @@ def test_apply_comment_without_image(monkeypatch):
     )
 
     res = asyncio.run(bot.apply_comment(update, context))
-    assert res == bot.SET_COMMENT
+    from telegram.ext import ConversationHandler
+    assert res == ConversationHandler.END

--- a/ai_dietolog/tests/test_edit_meal.py
+++ b/ai_dietolog/tests/test_edit_meal.py
@@ -49,7 +49,8 @@ def test_apply_comment_preserves_item_count(monkeypatch):
     )
 
     res = asyncio.run(bot.apply_comment(update, context))
-    assert res == bot.SET_COMMENT
+    from telegram.ext import ConversationHandler
+    assert res == ConversationHandler.END
     assert len(today.meals[0].items) == 1
     assert today.meals[0].total.kcal == 100
 
@@ -94,6 +95,7 @@ def test_apply_comment_updates_summary(monkeypatch):
     )
 
     res = asyncio.run(bot.apply_comment(update, context))
-    assert res == bot.SET_COMMENT
+    from telegram.ext import ConversationHandler
+    assert res == ConversationHandler.END
     assert today.summary.kcal == 150
     assert today.summary.protein_g == 12


### PR DESCRIPTION
## Summary
- end comment conversations after submitting a comment so further messages do not get misrouted
- update tests for the new behaviour
- restore correct return values for `cancel` and starting comment state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888897604cc83248637f366ca6ac2a8