### PR TITLE
Improve meal comment updates

### DIFF
--- a/ai_dietolog/agents/meal_editor.py
+++ b/ai_dietolog/agents/meal_editor.py
@@ -102,8 +102,11 @@ async def edit_meal(
         return existing_meal
 
     if len(items) != len(existing_meal.items):
-        logger.warning("Ignoring meal update due to item count mismatch")
-        return existing_meal
+        logger.info(
+            "Meal item count changed from %d to %d",
+            len(existing_meal.items),
+            len(items),
+        )
 
     return existing_meal.copy(update={
         "items": items,

--- a/ai_dietolog/bot/telegram_bot.py
+++ b/ai_dietolog/bot/telegram_bot.py
@@ -693,17 +693,16 @@ async def apply_comment(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     )
     meal.user_desc = user_desc
     meal.clarification = updated.clarification
-    if len(updated.items) == len(meal.items):
-        meal.items = updated.items
-        meal.total = updated.total
-        if not meal.pending:
-            for field in today.summary.model_fields:
-                value = (
-                    getattr(today.summary, field)
-                    - getattr(old_total, field)
-                    + getattr(meal.total, field)
-                )
-                setattr(today.summary, field, value)
+    meal.items = updated.items
+    meal.total = updated.total
+    if not meal.pending:
+        for field in today.summary.model_fields:
+            value = (
+                getattr(today.summary, field)
+                - getattr(old_total, field)
+                + getattr(meal.total, field)
+            )
+            setattr(today.summary, field, value)
     storage.save_today(user_id, today)
     keyboard = InlineKeyboardMarkup(
         [

--- a/ai_dietolog/core/prompts.py
+++ b/ai_dietolog/core/prompts.py
@@ -39,7 +39,8 @@ UPDATE_MEAL_JSON = Template(
     "Here is the current meal JSON:\n"
     "{{ meal }}\n\n"
     "The user added a comment: '{{ comment }}'.\n"
-    "Update the JSON to reflect this comment while keeping the same number of items.\n"
+    "Update the JSON to reflect this comment. Keep the existing items if possible,\n"
+    "but you may adjust them when the comment clearly changes the dish.\n"
     "Return only the updated JSON in {{ language }} without extra explanations."
 )
 

--- a/ai_dietolog/tests/test_edit_meal.py
+++ b/ai_dietolog/tests/test_edit_meal.py
@@ -7,7 +7,7 @@ from ai_dietolog.core.schema import Item, Meal, Total, Today
 from ai_dietolog.core import storage
 
 
-def test_apply_comment_preserves_item_count(monkeypatch):
+def test_apply_comment_updates_items(monkeypatch):
     meal = Meal(
         id="1",
         type="breakfast",
@@ -21,7 +21,6 @@ def test_apply_comment_preserves_item_count(monkeypatch):
     monkeypatch.setattr(storage, "save_today", lambda uid, t: None)
 
     async def fake_edit(existing_meal, comment, *, language="ru", history=None):
-        # Return a meal with an extra item which should be ignored
         new_item = Item(name="coffee", kcal=20)
         updated = existing_meal.copy()
         updated.items = existing_meal.items + [new_item]
@@ -51,8 +50,8 @@ def test_apply_comment_preserves_item_count(monkeypatch):
     res = asyncio.run(bot.apply_comment(update, context))
     from telegram.ext import ConversationHandler
     assert res == ConversationHandler.END
-    assert len(today.meals[0].items) == 1
-    assert today.meals[0].total.kcal == 100
+    assert len(today.meals[0].items) == 2
+    assert today.meals[0].total.kcal == 120
 
 
 def test_apply_comment_updates_summary(monkeypatch):


### PR DESCRIPTION
## Summary
- let OpenAI alter the meal item count when applying comments
- accept edited items in apply_comment regardless of item count
- tweak meal editing prompt text
- update tests for new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888970322ac8324a2d50701363729fd