### PR TITLE
Include sugar and fiber totals in meal history

### DIFF
--- a/ai_dietolog/core/schema.py
+++ b/ai_dietolog/core/schema.py
@@ -138,6 +138,8 @@ class MealBrief(BaseModel):
     protein_g: int = 0
     fat_g: int = 0
     carbs_g: int = 0
+    sugar_g: int = 0
+    fiber_g: int = 0
 
 
 class HistoryMealEntry(BaseModel):


### PR DESCRIPTION
## Summary
- extend `MealBrief` with `sugar_g` and `fiber_g`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a2cd86b08324972c47f79392c0f7