### PR TITLE
Handle Telegram photo download timeout

### DIFF
--- a/ai_dietolog/bot/telegram_bot.py
+++ b/ai_dietolog/bot/telegram_bot.py
@@ -25,6 +25,7 @@ from telegram import (
     ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
 )
+from telegram.error import TimedOut
 from telegram.ext import (
     Application,
     CommandHandler,
@@ -531,9 +532,15 @@ async def receive_meal_desc(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     file_id = None
     if update.message.photo:
         photo = update.message.photo[-1]
-        file = await photo.get_file()
-        image_bytes = await file.download_as_bytearray()
-        file_id = photo.file_id
+        try:
+            file = await photo.get_file()
+            image_bytes = await file.download_as_bytearray()
+            file_id = photo.file_id
+        except TimedOut:
+            await update.message.reply_text(
+                "Не удалось загрузить фото, попробуйте ещё раз."
+            )
+            return MEAL_DESC
     meal_type = context.user_data.get("meal_type", "Перекус")
     meal = await intake(
         image_bytes,

--- a/ai_dietolog/tests/conftest.py
+++ b/ai_dietolog/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for test imports
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/ai_dietolog/tests/test_receive_meal_timeout.py
+++ b/ai_dietolog/tests/test_receive_meal_timeout.py
@@ -1,0 +1,39 @@
+import asyncio
+from types import SimpleNamespace
+
+import ai_dietolog.bot.telegram_bot as bot
+
+
+def test_receive_meal_timeout(monkeypatch):
+    class DummyPhoto:
+        async def get_file(self):
+            from telegram.error import TimedOut
+            raise TimedOut("timeout")
+
+    class DummyBot:
+        def __init__(self):
+            self.messages = []
+
+        async def reply_text(self, text, reply_markup=None):
+            self.messages.append(text)
+            return SimpleNamespace()
+
+        async def reply_photo(self, photo, caption, reply_markup=None):
+            return SimpleNamespace()
+
+    dummy = DummyBot()
+    update = SimpleNamespace(
+        message=SimpleNamespace(
+            caption=None,
+            text="desc",
+            photo=[DummyPhoto()],
+            reply_text=dummy.reply_text,
+            reply_photo=dummy.reply_photo,
+        ),
+        effective_user=SimpleNamespace(id=1),
+    )
+    context = SimpleNamespace(user_data={})
+
+    res = asyncio.run(bot.receive_meal_desc(update, context))
+    assert res == bot.MEAL_DESC
+    assert dummy.messages


### PR DESCRIPTION
## Summary
- protect `receive_meal_desc` from `TimedOut` when downloading photos
- add pytest `conftest` to include project root on `sys.path`
- cover timeout case with unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a74652e883249d62a97f23f588bb