### PR TITLE
Fix Norms instantiation with defaults

### DIFF
--- a/ai_dietolog/core/schema.py
+++ b/ai_dietolog/core/schema.py
@@ -172,12 +172,20 @@ class Counters(BaseModel):
 
 
 class Norms(BaseModel):
-    BMR_kcal: int
-    TDEE_kcal: int
-    target_kcal: int
-    macros: Dict[str, int]
-    fiber_min_g: int
-    water_min_ml: int
+    """Nutritional norms calculated for a user."""
+
+    BMR_kcal: int = 0
+    TDEE_kcal: int = 0
+    target_kcal: int = 0
+    macros: Dict[str, int] = Field(
+        default_factory=lambda: {
+            "protein_g": 0,
+            "fat_g": 0,
+            "carbs_g": 0,
+        }
+    )
+    fiber_min_g: int = 0
+    water_min_ml: int = 0
 
 
 class MetricsCfg(BaseModel):


### PR DESCRIPTION
## Summary
- make Norms model fields optional and provide default values so empty profiles load correctly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b6c1b7dc8324a865a4829a34a1ee