### PR TITLE
Fix missing OpenAI key in context analysis

### DIFF
--- a/ai_dietolog/agents/contextual.py
+++ b/ai_dietolog/agents/contextual.py
@@ -6,6 +6,8 @@ import json
 from typing import Optional
 from openai import AsyncOpenAI
 
+from ..core.config import openai_api_key
+
 from ..core.prompts import CONTEXT_ANALYSIS
 from ..core.schema import Total
 
@@ -20,7 +22,7 @@ async def analyze_context(
     history: Optional[list[str]] = None,
 ) -> dict:
     """Return updated summary and comment for the new meal."""
-    client = AsyncOpenAI(api_key=cfg.get("openai_api_key"))
+    client = AsyncOpenAI(api_key=cfg.get("openai_api_key") or openai_api_key())
     system = CONTEXT_ANALYSIS.render(
         norms=json.dumps(profile_norms, ensure_ascii=False),
         day_summary=json.dumps(day_summary.model_dump(), ensure_ascii=False),

--- a/ai_dietolog/agents/daily_review.py
+++ b/ai_dietolog/agents/daily_review.py
@@ -7,6 +7,8 @@ from typing import Optional, Sequence
 
 from openai import AsyncOpenAI
 
+from ..core.config import openai_api_key
+
 from ..core.prompts import DAY_ANALYSIS
 from ..core.schema import MealBrief, Total
 
@@ -22,7 +24,7 @@ async def analyze_day(
 ) -> str:
     """Return bullet point comments about the day."""
 
-    client = AsyncOpenAI(api_key=cfg.get("openai_api_key"))
+    client = AsyncOpenAI(api_key=cfg.get("openai_api_key") or openai_api_key())
     system = DAY_ANALYSIS.render(
         norms=json.dumps(profile_norms, ensure_ascii=False),
         summary=json.dumps(summary.model_dump(), ensure_ascii=False),

--- a/ai_dietolog/agents/norms_ai.py
+++ b/ai_dietolog/agents/norms_ai.py
@@ -7,13 +7,15 @@ from typing import Optional
 
 from openai import AsyncOpenAI
 
+from ..core.config import openai_api_key
+
 from ..core.prompts import AI_NORMS
 from ..core.schema import Norms
 
 
 async def compute_norms_llm(profile_data: dict, cfg: dict, *, language: str = "ru") -> Norms:
     """Return ``Norms`` calculated by a language model."""
-    client = AsyncOpenAI(api_key=cfg.get("openai_api_key"))
+    client = AsyncOpenAI(api_key=cfg.get("openai_api_key") or openai_api_key())
     system = AI_NORMS.render(
         profile=json.dumps(profile_data, ensure_ascii=False),
         language=language,


### PR DESCRIPTION
## Summary
- ensure `AsyncOpenAI` uses env fallback for `openai_api_key`
- apply fix to `contextual`, `norms_ai`, and `daily_review` agents

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68890cd2d0f4832487a63ddee05c1e15