### PR TITLE
Fix meal conversation stuck after adding meal

### DIFF
--- a/ai_dietolog/bot/telegram_bot.py
+++ b/ai_dietolog/bot/telegram_bot.py
@@ -612,16 +612,12 @@ async def receive_meal_desc(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     if meal.clarification:
         text += f"\n\n❓ {meal.clarification}"
     if file_id:
-        sent = await update.message.reply_photo(
+        await update.message.reply_photo(
             photo=file_id, caption=text, reply_markup=keyboard
         )
     else:
-        sent = await update.message.reply_text(text, reply_markup=keyboard)
+        await update.message.reply_text(text, reply_markup=keyboard)
 
-    if meal.clarification:
-        context.user_data["comment_meal_id"] = meal.id
-        context.user_data["comment_message"] = (sent.chat_id, sent.message_id)
-        return SET_COMMENT
     return ConversationHandler.END
 
 

--- a/ai_dietolog/tests/test_clarification_flow.py
+++ b/ai_dietolog/tests/test_clarification_flow.py
@@ -50,7 +50,8 @@ def test_receive_meal_asks_for_clarification(monkeypatch):
     context = SimpleNamespace(user_data={})
 
     res = asyncio.run(bot.receive_meal_desc(update, context))
-    assert res == bot.SET_COMMENT
-    assert context.user_data["comment_meal_id"] == "1"
-    assert context.user_data["comment_message"] == (2, 3)
+    from telegram.ext import ConversationHandler
+    assert res == ConversationHandler.END
+    assert "comment_meal_id" not in context.user_data
+    assert "comment_message" not in context.user_data
 


### PR DESCRIPTION
## Summary
- end meal conversation in `receive_meal_desc`
- update clarification flow test accordingly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889104cbc1883249dd11833e6cd096e