### PR TITLE
Include text in meal edit prompt

### DIFF
--- a/ai_dietolog/agents/meal_editor.py
+++ b/ai_dietolog/agents/meal_editor.py
@@ -34,6 +34,7 @@ async def edit_meal(
     """
     system = UPDATE_MEAL_JSON.render(
         meal=json.dumps(existing_meal.model_dump(mode="json"), ensure_ascii=False),
+        user_desc=existing_meal.user_desc,
         comment=comment,
         language=language,
     )

--- a/ai_dietolog/core/prompts.py
+++ b/ai_dietolog/core/prompts.py
@@ -36,11 +36,13 @@ MEAL_JSON = Template(
 # Template for refining a meal with additional comments
 UPDATE_MEAL_JSON = Template(
     "You are a nutrition assistant.\n"
-    "Here is the current meal JSON:\n"
+    "Here is the current meal JSON with its nutrition data:\n"
     "{{ meal }}\n\n"
-    "The user added a comment: '{{ comment }}'.\n"
-    "Update the JSON to reflect this comment. Keep the existing items if possible,\n"
-    "but you may adjust them when the comment clearly changes the dish.\n"
+    "Original user description: '{{ user_desc }}'.\n"
+    "The user added a new comment: '{{ comment }}'.\n"
+    "Recalculate the meal according to this comment, updating all nutrition"
+    " values if they change. Keep the existing items when possible but adjust"
+    " them if the comment clearly alters the dish.\n"
     "Return only the updated JSON in {{ language }} without extra explanations."
 )
 


### PR DESCRIPTION
## Summary
- provide full meal description to the update prompt
- adjust meal editor to pass description

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889ba21b8c08324980b833ffe309d9d