### PR TITLE
Fix deleting meals sent as photos

### DIFF
--- a/ai_dietolog/bot/telegram_bot.py
+++ b/ai_dietolog/bot/telegram_bot.py
@@ -805,7 +805,10 @@ async def delete_meal(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
             )
     today.meals = [m for m in today.meals if m.id != meal_id]
     storage.save_today(user_id, today)
-    await query.message.edit_text("Удалено")
+    if query.message.photo:
+        await query.message.edit_caption("Удалено")
+    else:
+        await query.message.edit_text("Удалено")
 
 
 async def finish_day(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/ai_dietolog/tests/test_delete_meal_photo.py
+++ b/ai_dietolog/tests/test_delete_meal_photo.py
@@ -1,0 +1,51 @@
+import asyncio
+from types import SimpleNamespace
+from datetime import datetime
+
+import ai_dietolog.bot.telegram_bot as bot
+from ai_dietolog.core.schema import Item, Meal, Total, Today
+from ai_dietolog.core import storage
+
+
+def test_delete_meal_photo(monkeypatch):
+    meal = Meal(
+        id="1",
+        type="breakfast",
+        items=[Item(name="apple", kcal=50)],
+        total=Total(kcal=50),
+        timestamp=datetime.utcnow(),
+        image_file_id="file123",
+    )
+    today = Today(meals=[meal], summary=Total(kcal=50))
+    monkeypatch.setattr(storage, "load_today", lambda uid: today)
+    monkeypatch.setattr(storage, "save_today", lambda uid, t: None)
+
+    edits = {}
+
+    class DummyMessage:
+        photo = [object()]
+
+        async def edit_caption(self, text):
+            edits["caption"] = text
+
+        async def edit_text(self, text):
+            edits["text"] = text
+
+        async def reply_text(self, *a, **k):
+            pass
+
+    class DummyQuery:
+        data = "delete:1"
+        message = DummyMessage()
+
+        async def answer(self, *a, **k):
+            pass
+
+    update = SimpleNamespace(callback_query=DummyQuery(), effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace()
+
+    asyncio.run(bot.delete_meal(update, context))
+
+    assert edits.get("caption") == "Удалено"
+    assert "text" not in edits
+    assert len(today.meals) == 0


### PR DESCRIPTION
## Summary
- avoid `edit_text` error when deleting photo messages
- test `delete_meal` on messages with a photo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889be3eb210832489d3f71c30f26136