### PR TITLE
fix: preserve summary when meal analysis missing

### DIFF
--- a/ai_dietolog/tests/test_confirm_meal.py
+++ b/ai_dietolog/tests/test_confirm_meal.py
@@ -49,3 +49,50 @@ def test_confirm_meal_updates_summary(monkeypatch):
 
     assert today.meals[0].pending is False
     assert today.summary.kcal == 50
+
+
+def test_confirm_meal_empty_summary_does_not_reset(monkeypatch):
+    meal = Meal(
+        id="1",
+        type="breakfast",
+        items=[Item(name="apple", kcal=50)],
+        total=Total(kcal=50),
+        timestamp=datetime.utcnow(),
+    )
+    today = Today(meals=[meal], summary=Total())
+
+    monkeypatch.setattr(storage, "load_today", lambda uid: today)
+    monkeypatch.setattr(storage, "save_today", lambda uid, t: None)
+    monkeypatch.setattr(storage, "load_profile", lambda uid, cls: Profile())
+    monkeypatch.setattr(bot, "load_config", lambda: {})
+
+    async def fake_analyze_context(*args, **kwargs):
+        return {"summary": {}}
+
+    monkeypatch.setattr(bot, "analyze_context", fake_analyze_context)
+
+    class DummyMsg:
+        photo = None
+
+        async def edit_text(self, *a, **k):
+            pass
+
+        async def reply_text(self, *a, **k):
+            pass
+
+        async def edit_caption(self, *a, **k):
+            pass
+
+    class DummyQuery:
+        data = "confirm:1"
+        message = DummyMsg()
+
+        async def answer(self):
+            pass
+
+    update = SimpleNamespace(callback_query=DummyQuery(), effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    asyncio.run(bot.confirm_meal(update, context))
+
+    assert today.summary.kcal == 50


### PR DESCRIPTION
## Summary
- avoid resetting daily totals when meal analysis returns an empty summary
- add regression test for missing summary from meal analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688caa863e8883249a6fce9af6f3b7be