### PR TITLE
fix: preserve summary when meal analysis missing

### DIFF
--- a/ai_dietolog/tests/test_confirm_meal.py
+++ b/ai_dietolog/tests/test_confirm_meal.py
@@ -49,3 +49,50 @@ def test_confirm_meal_updates_summary(monkeypatch):
 
     assert today.meals[0].pending is False
     assert today.summary.kcal == 50
+
+
+def test_confirm_meal_empty_summary_does_not_reset(monkeypatch):
+    meal = Meal(
+        id="1",
+        type="breakfast",
+        items=[Item(name="apple", kcal=50)],
+        total=Total(kcal=50),
+        timestamp=datetime.utcnow(),
+    )
+    today = Today(meals=[meal], summary=Total())
+
+    monkeypatch.setattr(storage, "load_today", lambda uid: today)
+    monkeypatch.setattr(storage, "save_today", lambda uid, t: None)
+    monkeypatch.setattr(storage, "load_profile", lambda uid, cls: Profile())
+    monkeypatch.setattr(bot, "load_config", lambda: {})
+
+    async def fake_analyze_context(*args, **kwargs):
+        return {"summary": {}}
+
+    monkeypatch.setattr(bot, "analyze_context", fake_analyze_context)
+
+    class DummyMsg:
+        photo = None
+
+        async def edit_text(self, *a, **k):
+            pass
+
+        async def reply_text(self, *a, **k):
+            pass
+
+        async def edit_caption(self, *a, **k):
+            pass
+
+    class DummyQuery:
+        data = "confirm:1"
+        message = DummyMsg()
+
+        async def answer(self):
+            pass
+
+    update = SimpleNamespace(callback_query=DummyQuery(), effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    asyncio.run(bot.confirm_meal(update, context))
+
+    assert today.summary.kcal == 50

--- a/ai_dietolog/tests/test_storage_write.py
+++ b/ai_dietolog/tests/test_storage_write.py
@@ -1,0 +1,24 @@
+import json
+import math
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from ai_dietolog.core import storage
+
+
+class Dummy(BaseModel):
+    x: float
+
+
+def test_write_json_atomic_on_nan(tmp_path: Path):
+    target = tmp_path / "data.json"
+    # initial valid write
+    storage.write_json(target, Dummy(x=1.0))
+    assert json.loads(target.read_text()) == {"x": 1.0}
+
+    # attempt to write NaN should raise and leave file untouched
+    with pytest.raises(ValueError):
+        storage.write_json(target, Dummy(x=math.nan))
+    assert json.loads(target.read_text()) == {"x": 1.0}


### PR DESCRIPTION
## Summary
- avoid resetting daily totals when meal analysis returns an empty summary
- add regression test for missing summary from meal analysis
- ensure atomic storage writes reject NaN values so meal logs can't be corrupted
- add test verifying failed writes leave existing data intact

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688caa863e8883249a6fce9af6f3b7be