### PR TITLE
fix: persist meal confirmation before analysis

### DIFF
--- a/ai_dietolog/tests/test_confirm_meal.py
+++ b/ai_dietolog/tests/test_confirm_meal.py
@@ -49,3 +49,116 @@ def test_confirm_meal_updates_summary(monkeypatch):
 
     assert today.meals[0].pending is False
     assert today.summary.kcal == 50
+
+
+def test_confirm_meal_empty_summary_does_not_reset(monkeypatch):
+    meal = Meal(
+        id="1",
+        type="breakfast",
+        items=[Item(name="apple", kcal=50)],
+        total=Total(kcal=50),
+        timestamp=datetime.utcnow(),
+    )
+    today = Today(meals=[meal], summary=Total())
+
+    monkeypatch.setattr(storage, "load_today", lambda uid: today)
+    monkeypatch.setattr(storage, "save_today", lambda uid, t: None)
+    monkeypatch.setattr(storage, "load_profile", lambda uid, cls: Profile())
+    monkeypatch.setattr(bot, "load_config", lambda: {})
+
+    async def fake_analyze_context(*args, **kwargs):
+        return {"summary": {}}
+
+    monkeypatch.setattr(bot, "analyze_context", fake_analyze_context)
+
+    class DummyMsg:
+        photo = None
+
+        async def edit_text(self, *a, **k):
+            pass
+
+        async def reply_text(self, *a, **k):
+            pass
+
+        async def edit_caption(self, *a, **k):
+            pass
+
+    class DummyQuery:
+        data = "confirm:1"
+        message = DummyMsg()
+
+        async def answer(self):
+            pass
+
+    update = SimpleNamespace(callback_query=DummyQuery(), effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    asyncio.run(bot.confirm_meal(update, context))
+
+    assert today.summary.kcal == 50
+
+
+def test_confirm_meal_saves_before_analysis(monkeypatch):
+    meal = Meal(
+        id="1",
+        type="breakfast",
+        items=[Item(name="apple", kcal=50)],
+        total=Total(kcal=50),
+        timestamp=datetime.utcnow(),
+    )
+    today = Today(meals=[meal], summary=Total())
+
+    monkeypatch.setattr(storage, "load_today", lambda uid: today)
+
+    saved: list[Today] = []
+
+    def fake_save(uid, t):
+        # store a deep copy to inspect later
+        saved.append(t.model_copy(deep=True))
+
+    monkeypatch.setattr(storage, "save_today", fake_save)
+    monkeypatch.setattr(storage, "load_profile", lambda uid, cls: Profile())
+    monkeypatch.setattr(bot, "load_config", lambda: {})
+
+    event = asyncio.Event()
+
+    async def slow_analyze_context(*args, **kwargs):
+        await event.wait()
+        return {}
+
+    monkeypatch.setattr(bot, "analyze_context", slow_analyze_context)
+
+    class DummyMsg:
+        photo = None
+
+        async def edit_text(self, *a, **k):
+            pass
+
+        async def reply_text(self, *a, **k):
+            pass
+
+        async def edit_caption(self, *a, **k):
+            pass
+
+    class DummyQuery:
+        data = "confirm:1"
+        message = DummyMsg()
+
+        async def answer(self):
+            await event.wait()
+
+    update = SimpleNamespace(callback_query=DummyQuery(), effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    async def run_and_signal():
+        task = asyncio.create_task(bot.confirm_meal(update, context))
+        await asyncio.sleep(0.1)
+        # The save should have happened even though both query.answer and
+        # analyze_context are waiting on the event.
+        assert len(saved) == 1
+        assert saved[0].meals[0].pending is False
+        assert saved[0].summary.kcal == 50
+        event.set()
+        await task
+
+    asyncio.run(run_and_signal())

--- a/ai_dietolog/tests/test_storage_write.py
+++ b/ai_dietolog/tests/test_storage_write.py
@@ -1,0 +1,24 @@
+import json
+import math
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from ai_dietolog.core import storage
+
+
+class Dummy(BaseModel):
+    x: float
+
+
+def test_write_json_atomic_on_nan(tmp_path: Path):
+    target = tmp_path / "data.json"
+    # initial valid write
+    storage.write_json(target, Dummy(x=1.0))
+    assert json.loads(target.read_text()) == {"x": 1.0}
+
+    # attempt to write NaN should raise and leave file untouched
+    with pytest.raises(ValueError):
+        storage.write_json(target, Dummy(x=math.nan))
+    assert json.loads(target.read_text()) == {"x": 1.0}


### PR DESCRIPTION
## Summary
- confirm meals and persist them before triggering slow analysis to prevent day summaries missing recent meals
- add debug logging for today.json reads and writes and extra info logs during meal confirmation
- add regression test ensuring confirmation is saved even if analysis is delayed
- answer callback queries asynchronously so meal persistence happens before yielding control, avoiding races with day-end summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688caa863e8883249a6fce9af6f3b7be