### PR TITLE
Persist meal confirmation analysis updates

### DIFF
--- a/ai_dietolog/bot/handlers/meal_logging.py
+++ b/ai_dietolog/bot/handlers/meal_logging.py
@@ -246,6 +246,16 @@ async def confirm_meal(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         # previously confirmed meal totals.
         today.summary = today.summary.model_copy(update=result["summary"])
 
+    # Persist updates from context analysis so that subsequent commands such
+    # as ``finish_day`` can see the latest meal list and summary.
+    storage.save_today(user_id, today)
+    logger.info(
+        "Analysis updates saved for meal %s | user %s | summary=%s",
+        meal_id,
+        user_id,
+        today.summary.model_dump(),
+    )
+
     if hasattr(context, "user_data"):
         context.user_data.get("meals", {}).pop(meal_id, None)
     if query.message.photo:

--- a/ai_dietolog/tests/test_confirm_meal.py
+++ b/ai_dietolog/tests/test_confirm_meal.py
@@ -96,3 +96,53 @@ def test_confirm_meal_empty_summary_does_not_reset(monkeypatch):
     asyncio.run(bot.confirm_meal(update, context))
 
     assert today.summary.kcal == 50
+
+
+def test_confirm_meal_persists_analysis_updates(tmp_path, monkeypatch):
+    meal = Meal(
+        id="1",
+        type="breakfast",
+        items=[Item(name="apple", kcal=50)],
+        total=Total(kcal=50),
+        timestamp=datetime.utcnow(),
+    )
+    # Save initial pending meal to temporary storage
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+    storage.save_today(1, Today(meals=[meal], summary=Total()))
+
+    monkeypatch.setattr(storage, "load_profile", lambda uid, cls: Profile())
+    monkeypatch.setattr(bot, "load_config", lambda: {})
+
+    async def fake_analyze_context(*args, **kwargs):
+        return {"summary": {"kcal": 200}}
+
+    monkeypatch.setattr(bot, "analyze_context", fake_analyze_context)
+
+    class DummyMsg:
+        photo = None
+
+        async def edit_text(self, *a, **k):
+            pass
+
+        async def reply_text(self, *a, **k):
+            pass
+
+        async def edit_caption(self, *a, **k):
+            pass
+
+    class DummyQuery:
+        data = "confirm:1"
+        message = DummyMsg()
+
+        async def answer(self):
+            pass
+
+    update = SimpleNamespace(callback_query=DummyQuery(), effective_user=SimpleNamespace(id=1))
+    context = SimpleNamespace(user_data={})
+
+    asyncio.run(bot.confirm_meal(update, context))
+
+    loaded = storage.load_today(1)
+    assert loaded.summary.kcal == 200
+    assert len(loaded.meals) == 1
+    assert loaded.meals[0].pending is False


### PR DESCRIPTION
## Summary
- Ensure analysis results from meal confirmation are written back to `today.json`
- Add regression test verifying that confirmed meals persist analysis updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cb89ab6d883248b1d4007f17f1c19