### PR TITLE
Fix missing meal persistence before day summary

### DIFF
--- a/ai_dietolog/bot/handlers/meal_logging.py
+++ b/ai_dietolog/bot/handlers/meal_logging.py
@@ -222,7 +222,13 @@ async def confirm_meal(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             await query.message.reply_text("Запись не найдена")
             return
         logger.debug("Using in-memory meal %s for confirmation", meal_id)
-        today.append_meal(meal)
+        # Persist the meal immediately so that subsequent reads load it from
+        # ``today.json``.  This avoids situations where the in-memory object
+        # is appended to a transient ``Today`` instance that was never written
+        # to disk, leaving ``today.json`` empty and causing ``finish_day`` to
+        # miss the confirmed meal.
+        storage.append_meal(user_id, meal)
+        today = storage.load_today(user_id)
         logger.debug("Appended in-memory meal %s to today's log", meal_id)
     logger.info("Confirming meal %s for user %s", meal_id, user_id)
     if not meal.pending:


### PR DESCRIPTION
## Summary
- Ensure meals retrieved from memory are written to `today.json` before confirmation
- Reload today's data after persisting to avoid missing meals in day summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e02fcf9ac83249b119eebde4f8128