### PR TITLE
Handle GPT-5 temperature limitations

### DIFF
--- a/ai_dietolog/agents/contextual.py
+++ b/ai_dietolog/agents/contextual.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import json
 from typing import Optional
 from ..core.llm import ask_llm
-from openai import AsyncOpenAI  # noqa: F401
-from ..core.config import openai_api_key, load_config, agent_llm
+from ..core.config import load_config, agent_llm
 
 from ..core.prompts import CONTEXT_ANALYSIS
 from ..core.schema import Total
@@ -43,22 +42,12 @@ async def analyze_context(
     messages.append({"role": "system", "content": system})
     cfg = {**load_config(), **cfg}
     provider, model = agent_llm("contextual", cfg)
-    if provider == "openai":
-        client = AsyncOpenAI(api_key=cfg.get("openai_api_key") or openai_api_key())
-        resp = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=0.3,
-            response_format={"type": "json_object"},
-        )
-        content = resp.choices[0].message.content
-    else:
-        content = await ask_llm(
-            messages,
-            model=model,
-            provider=provider,
-            temperature=0.3,
-            response_format={"type": "json_object"},
-            cfg=cfg,
-        )
+    content = await ask_llm(
+        messages,
+        model=model,
+        provider=provider,
+        temperature=0.3,
+        response_format={"type": "json_object"},
+        cfg=cfg,
+    )
     return json.loads(content)

--- a/ai_dietolog/agents/daily_review.py
+++ b/ai_dietolog/agents/daily_review.py
@@ -6,8 +6,7 @@ import json
 from typing import Optional, Sequence
 
 from ..core.llm import ask_llm
-from openai import AsyncOpenAI  # noqa: F401
-from ..core.config import openai_api_key, load_config, agent_llm
+from ..core.config import load_config, agent_llm
 
 from ..core.prompts import DAY_ANALYSIS
 from ..core.schema import MealBrief, Total
@@ -45,20 +44,11 @@ async def analyze_day(
     messages.append({"role": "system", "content": system})
     cfg = {**load_config(), **cfg}
     provider, model = agent_llm("daily_review", cfg)
-    if provider == "openai":
-        client = AsyncOpenAI(api_key=cfg.get("openai_api_key") or openai_api_key())
-        resp = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=0.3,
-        )
-        text = resp.choices[0].message.content
-    else:
-        text = await ask_llm(
-            messages,
-            model=model,
-            provider=provider,
-            temperature=0.3,
-            cfg=cfg,
-        )
+    text = await ask_llm(
+        messages,
+        model=model,
+        provider=provider,
+        temperature=0.3,
+        cfg=cfg,
+    )
     return text.strip()

--- a/ai_dietolog/agents/intake.py
+++ b/ai_dietolog/agents/intake.py
@@ -10,8 +10,7 @@ from uuid import uuid4
 from typing import Optional
 
 from ..core.llm import ask_llm
-from openai import AsyncOpenAI  # noqa: F401
-from ..core.config import openai_api_key, load_config, agent_llm
+from ..core.config import load_config, agent_llm
 from pydantic import ValidationError
 
 from ..core.prompts import MEAL_JSON
@@ -75,24 +74,14 @@ async def intake(
 
     cfg = load_config()
     provider, model = agent_llm("intake", cfg)
-    if provider == "openai":
-        client = AsyncOpenAI(api_key=cfg.get("openai_api_key") or openai_api_key())
-        resp = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=0,
-            response_format={"type": "json_object"},
-        )
-        content = resp.choices[0].message.content
-    else:
-        content = await ask_llm(
-            messages,
-            model=model,
-            provider=provider,
-            temperature=0,
-            response_format={"type": "json_object"},
-            cfg=cfg,
-        )
+    content = await ask_llm(
+        messages,
+        model=model,
+        provider=provider,
+        temperature=0,
+        response_format={"type": "json_object"},
+        cfg=cfg,
+    )
     data = json.loads(content)
     logger.info("Process: intake | Agent: intake | Raw response: %s", content)
 

--- a/ai_dietolog/agents/meal_editor.py
+++ b/ai_dietolog/agents/meal_editor.py
@@ -7,8 +7,7 @@ import logging
 from typing import Optional
 
 from ..core.llm import ask_llm
-from openai import AsyncOpenAI  # noqa: F401
-from ..core.config import openai_api_key, load_config, agent_llm
+from ..core.config import load_config, agent_llm
 from pydantic import ValidationError
 
 from ..core.prompts import UPDATE_MEAL_JSON
@@ -54,24 +53,14 @@ async def edit_meal(
     messages.append({"role": "user", "content": comment})
     cfg = load_config()
     provider, model = agent_llm("meal_editor", cfg)
-    if provider == "openai":
-        client = AsyncOpenAI(api_key=cfg.get("openai_api_key") or openai_api_key())
-        resp = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=0,
-            response_format={"type": "json_object"},
-        )
-        content = resp.choices[0].message.content
-    else:
-        content = await ask_llm(
-            messages,
-            model=model,
-            provider=provider,
-            temperature=0,
-            response_format={"type": "json_object"},
-            cfg=cfg,
-        )
+    content = await ask_llm(
+        messages,
+        model=model,
+        provider=provider,
+        temperature=0,
+        response_format={"type": "json_object"},
+        cfg=cfg,
+    )
     try:
         data = parse_json_block(content)
     except json.JSONDecodeError as exc:  # noqa: BLE001

--- a/ai_dietolog/agents/norms_ai.py
+++ b/ai_dietolog/agents/norms_ai.py
@@ -6,8 +6,7 @@ import json
 from typing import Optional
 
 from ..core.llm import ask_llm
-from openai import AsyncOpenAI  # noqa: F401
-from ..core.config import openai_api_key, load_config, agent_llm
+from ..core.config import load_config, agent_llm
 
 from ..core.prompts import AI_NORMS
 from ..core.schema import Norms
@@ -27,21 +26,12 @@ async def compute_norms_llm(
         language=language,
     )
     messages = [{"role": "system", "content": system}]
-    if provider == "openai":
-        client = AsyncOpenAI(api_key=cfg.get("openai_api_key") or openai_api_key())
-        resp = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=0,
-        )
-        text = resp.choices[0].message.content
-    else:
-        text = await ask_llm(
-            messages,
-            model=model,
-            provider=provider,
-            temperature=0,
-            cfg=cfg,
-        )
+    text = await ask_llm(
+        messages,
+        model=model,
+        provider=provider,
+        temperature=0,
+        cfg=cfg,
+    )
     data = json.loads(text)
     return Norms(**data)

--- a/ai_dietolog/agents/profile_editor.py
+++ b/ai_dietolog/agents/profile_editor.py
@@ -6,7 +6,6 @@ import json
 import logging
 
 from ..core.llm import ask_llm
-from openai import AsyncOpenAI  # noqa: F401
 from ..core.config import load_config, agent_llm
 from ..core.prompts import PROFILE_TO_JSON
 
@@ -32,26 +31,17 @@ async def update_profile(
     )
     cfg = {**load_config(), "openai_api_key": api_key}
     provider, model = agent_llm("profile_editor", cfg)
-    if provider == "openai":
-        client = AsyncOpenAI(api_key=api_key)
-        resp = await client.chat.completions.create(
-            model=model,
-            messages=[{"role": "system", "content": system}, {"role": "user", "content": user_request}],
-            temperature=0,
-        )
-        content = resp.choices[0].message.content.strip()
-    else:
-        content = await ask_llm(
-            [
-                {"role": "system", "content": system},
-                {"role": "user", "content": user_request},
-            ],
-            model=model,
-            provider=provider,
-            temperature=0,
-            cfg=cfg,
-        )
-        content = content.strip()
+    content = await ask_llm(
+        [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user_request},
+        ],
+        model=model,
+        provider=provider,
+        temperature=0,
+        cfg=cfg,
+    )
+    content = content.strip()
     try:
         return json.loads(content)
     except json.JSONDecodeError as exc:  # noqa: BLE001

--- a/ai_dietolog/bot/handlers/profile_setup.py
+++ b/ai_dietolog/bot/handlers/profile_setup.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 
-from openai import AsyncOpenAI  # noqa: F401
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ConversationHandler, ContextTypes
 
@@ -107,22 +106,13 @@ async def ai_explain(prompt: str, api_key: str) -> str:
         },
         {"role": "user", "content": prompt},
     ]
-    if provider == "openai":
-        client = AsyncOpenAI(api_key=api_key)
-        resp = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=0.5,
-        )
-        content = resp.choices[0].message.content
-    else:
-        content = await ask_llm(
-            messages,
-            model=model,
-            provider=provider,
-            temperature=0.5,
-            cfg=cfg,
-        )
+    content = await ask_llm(
+        messages,
+        model=model,
+        provider=provider,
+        temperature=0.5,
+        cfg=cfg,
+    )
     return content.strip()
 
 
@@ -134,22 +124,13 @@ async def _extract(text: str, api_key: str, system: str) -> dict:
         {"role": "system", "content": system},
         {"role": "user", "content": text},
     ]
-    if provider == "openai":
-        client = AsyncOpenAI(api_key=api_key)
-        resp = await client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=0,
-        )
-        content = resp.choices[0].message.content
-    else:
-        content = await ask_llm(
-            messages,
-            model=model,
-            provider=provider,
-            temperature=0,
-            cfg=cfg,
-        )
+    content = await ask_llm(
+        messages,
+        model=model,
+        provider=provider,
+        temperature=0,
+        cfg=cfg,
+    )
     return json.loads(content)
 
 

--- a/ai_dietolog/core/llm.py
+++ b/ai_dietolog/core/llm.py
@@ -93,8 +93,10 @@ async def ask_llm(
         kwargs = {
             "model": model,
             "messages": messages,
-            "temperature": temperature,
         }
+        # Some models (e.g. GPT-5) allow only the default temperature.
+        if not model.lower().startswith("gpt-5"):
+            kwargs["temperature"] = temperature
         if response_format is not None:
             kwargs["response_format"] = response_format
         resp = await client.chat.completions.create(**kwargs)

--- a/ai_dietolog/tests/test_daily_review.py
+++ b/ai_dietolog/tests/test_daily_review.py
@@ -6,26 +6,10 @@ from ai_dietolog.core.schema import Total, MealBrief
 def test_daily_review_format(monkeypatch):
     resp_text = "- comment1\n- comment2\n- comment3\n- comment4\n- comment5"
 
-    async def fake_create(*args, **kwargs):
-        class Message:
-            def __init__(self, content):
-                self.content = resp_text
+    async def fake_ask_llm(*args, **kwargs):
+        return resp_text
 
-        class Choice:
-            def __init__(self):
-                self.message = Message(resp_text)
-
-        class Resp:
-            def __init__(self):
-                self.choices = [Choice()]
-
-        return Resp()
-
-    class FakeClient:
-        def __init__(self):
-            self.chat = type("Chat", (), {"completions": type("Comp", (), {"create": fake_create})()})()
-
-    monkeypatch.setattr(daily_review, "AsyncOpenAI", lambda api_key=None: FakeClient())
+    monkeypatch.setattr(daily_review, "ask_llm", fake_ask_llm)
 
     norms = {"target_kcal": 2000}
     summary = Total(kcal=2100)

--- a/ai_dietolog/tests/test_intake_clarification.py
+++ b/ai_dietolog/tests/test_intake_clarification.py
@@ -12,28 +12,10 @@ def test_optional_clarification(monkeypatch):
     }
     meal_json = json.dumps(resp)
 
-    async def fake_create(*args, **kwargs):
-        class Message:
-            def __init__(self, content):
-                self.content = meal_json
+    async def fake_ask_llm(*args, **kwargs):
+        return meal_json
 
-        class Choice:
-            def __init__(self):
-                self.message = Message(meal_json)
-
-        class Resp:
-            def __init__(self):
-                self.choices = [Choice()]
-
-        return Resp()
-
-    class FakeClient:
-        def __init__(self):
-            self.chat = type(
-                "Chat", (), {"completions": type("Comp", (), {"create": fake_create})()}
-            )()
-
-    monkeypatch.setattr(intake_module, "AsyncOpenAI", lambda *a, **k: FakeClient())
+    monkeypatch.setattr(intake_module, "ask_llm", fake_ask_llm)
 
     meal = asyncio.run(
         intake_module.intake(image=None, user_text="pie", meal_type="breakfast")

--- a/ai_dietolog/tests/test_intake_rounding.py
+++ b/ai_dietolog/tests/test_intake_rounding.py
@@ -13,28 +13,10 @@ def test_fractional_macros_rounding(monkeypatch):
     }
     meal_json = json.dumps(meal_resp)
 
-    async def fake_create(*args, **kwargs):
-        class Message:
-            def __init__(self, content):
-                self.content = meal_json
+    async def fake_ask_llm(*args, **kwargs):
+        return meal_json
 
-        class Choice:
-            def __init__(self):
-                self.message = Message(meal_json)
-
-        class Resp:
-            def __init__(self):
-                self.choices = [Choice()]
-
-        return Resp()
-
-    class FakeClient:
-        def __init__(self):
-            self.chat = type(
-                "Chat", (), {"completions": type("Comp", (), {"create": fake_create})()}
-            )()
-
-    monkeypatch.setattr(intake_module, "AsyncOpenAI", lambda *a, **k: FakeClient())
+    monkeypatch.setattr(intake_module, "ask_llm", fake_ask_llm)
 
     meal = asyncio.run(
         intake_module.intake(image=None, user_text="apple", meal_type="breakfast")


### PR DESCRIPTION
## Summary
- Avoid passing temperature to GPT-5 by filtering it in ask_llm
- Route agents and handlers through ask_llm for consistent OpenAI calls
- Update tests to mock ask_llm instead of AsyncOpenAI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898423ed318832497e36632d169ae32