### PR TITLE
Fix comment lookup for unsaved meals

### DIFF
--- a/ai_dietolog/bot/handlers/meal_logging.py
+++ b/ai_dietolog/bot/handlers/meal_logging.py
@@ -387,8 +387,17 @@ async def apply_comment(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     today = storage.load_today(user_id)
     meal = next((m for m in today.meals if m.id == meal_id), None)
     if not meal:
-        await update.message.reply_text("Запись не найдена")
-        return ConversationHandler.END
+        meal = getattr(context, "user_data", {}).get("meals", {}).get(meal_id)
+        if meal:
+            today.append_meal(meal)
+            logger.debug(
+                "Process: apply_comment | Agent: meal_logging | User: %s | Appended in-memory meal %s",
+                user_id,
+                meal_id,
+            )
+        else:
+            await update.message.reply_text("Запись не найдена")
+            return ConversationHandler.END
     old_total = meal.total
     meal.comment = f"{meal.comment or ''} {comment}".strip()
     user_desc = f"{meal.user_desc} {comment}".strip()

--- a/ai_dietolog/tests/test_comment_in_memory_meal.py
+++ b/ai_dietolog/tests/test_comment_in_memory_meal.py
@@ -1,0 +1,53 @@
+import asyncio
+from types import SimpleNamespace
+from datetime import datetime
+
+import ai_dietolog.bot.handlers.meal_logging as bot
+from ai_dietolog.core.schema import Item, Meal, Total
+from ai_dietolog.core import storage
+
+
+def test_apply_comment_persists_in_memory_meal(tmp_path, monkeypatch):
+    meal = Meal(
+        id="1",
+        type="breakfast",
+        items=[Item(name="bread", kcal=80)],
+        total=Total(kcal=80),
+        timestamp=datetime.utcnow(),
+    )
+    meal.user_desc = "bread"
+
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+    storage.DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    async def fake_edit(existing_meal, comment, *, language="ru", history=None):
+        assert comment == "note"
+        return existing_meal
+
+    monkeypatch.setattr(bot, "edit_meal", fake_edit)
+
+    class DummyBot:
+        async def edit_message_text(self, **kwargs):
+            pass
+
+        async def edit_message_caption(self, **kwargs):
+            pass
+
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        effective_chat=SimpleNamespace(id=2),
+        effective_message=SimpleNamespace(message_id=3),
+        message=SimpleNamespace(text="note", reply_text=lambda *a, **k: None),
+    )
+    context = SimpleNamespace(
+        bot=DummyBot(),
+        user_data={"comment_meal_id": "1", "meals": {"1": meal}},
+    )
+
+    res = asyncio.run(bot.apply_comment(update, context))
+    from telegram.ext import ConversationHandler
+    assert res == ConversationHandler.END
+
+    loaded = storage.load_today(1)
+    assert len(loaded.meals) == 1
+    assert loaded.meals[0].comment == "note"


### PR DESCRIPTION
## Summary
- Allow comment handler to find meals stored only in memory and persist them
- Add regression test ensuring comments on unsaved meals are saved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898454cdcf88324bff4c8f55e37b14f