### PR TITLE
Fix meal comment flow and store day summary

### DIFF
--- a/ai_dietolog/bot/handlers/daily_review.py
+++ b/ai_dietolog/bot/handlers/daily_review.py
@@ -152,6 +152,7 @@ async def finish_day(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         date=datetime.utcnow().date().isoformat(),
         num_meals=len(confirmed),
         meals=briefs,
+        summary=today.summary.model_copy(),
         comment=comment_text,
     )
     context.user_data["history_entry"] = entry

--- a/ai_dietolog/bot/handlers/meal_logging.py
+++ b/ai_dietolog/bot/handlers/meal_logging.py
@@ -426,16 +426,17 @@ async def apply_comment(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         meal_id,
         storage.today_path(user_id),
     )
-    keyboard = InlineKeyboardMarkup(
-        [
-            [
-                InlineKeyboardButton(
-                    "✍\ufe0f Комментарии", callback_data=f"comment:{meal.id}"
-                ),
-                InlineKeyboardButton("🗑 Удалить", callback_data=f"delete:{meal.id}"),
-            ]
-        ]
-    )
+    # Always offer delete and comment actions.  If the meal is still pending,
+    # keep the "confirm" button so the user can finalise it after editing.
+    buttons = [
+        InlineKeyboardButton("✍\ufe0f Комментарии", callback_data=f"comment:{meal.id}"),
+        InlineKeyboardButton("🗑 Удалить", callback_data=f"delete:{meal.id}"),
+    ]
+    if meal.pending:
+        buttons.insert(
+            0, InlineKeyboardButton("✔ Подтвердить", callback_data=f"confirm:{meal.id}")
+        )
+    keyboard = InlineKeyboardMarkup([buttons])
     text = meal_breakdown(meal)
     if meal.clarification:
         text += f"\n\n❓ {meal.clarification}"

--- a/ai_dietolog/core/schema.py
+++ b/ai_dietolog/core/schema.py
@@ -148,6 +148,7 @@ class HistoryMealEntry(BaseModel):
     date: str
     num_meals: int
     meals: List[MealBrief]
+    summary: Total = Field(default_factory=Total)
     comment: str = ""
 
 

--- a/ai_dietolog/tests/test_comment_shows_confirm.py
+++ b/ai_dietolog/tests/test_comment_shows_confirm.py
@@ -1,0 +1,55 @@
+import asyncio
+from types import SimpleNamespace
+from datetime import datetime
+
+import ai_dietolog.bot.handlers.meal_logging as bot
+from ai_dietolog.core.schema import Item, Meal, Total, Today
+from ai_dietolog.core import storage
+
+
+def test_apply_comment_keeps_confirm_button(tmp_path, monkeypatch):
+    meal = Meal(
+        id="1",
+        type="breakfast",
+        items=[Item(name="bread", kcal=80)],
+        total=Total(kcal=80),
+        timestamp=datetime.utcnow(),
+    )
+    meal.user_desc = "bread"
+
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+    storage.DATA_DIR.mkdir(parents=True, exist_ok=True)
+    storage.save_today(1, Today(meals=[meal], summary=Total()))
+
+    async def fake_edit(existing_meal, comment, *, language="ru", history=None):
+        return existing_meal
+
+    monkeypatch.setattr(bot, "edit_meal", fake_edit)
+
+    captured = {}
+
+    class DummyBot:
+        async def edit_message_text(self, **kwargs):
+            captured["markup"] = kwargs.get("reply_markup")
+
+        async def edit_message_caption(self, **kwargs):
+            captured["markup"] = kwargs.get("reply_markup")
+
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        effective_chat=SimpleNamespace(id=2),
+        effective_message=SimpleNamespace(message_id=3),
+        message=SimpleNamespace(text="note", reply_text=lambda *a, **k: None),
+    )
+    context = SimpleNamespace(
+        bot=DummyBot(),
+        user_data={"comment_meal_id": "1"},
+    )
+
+    res = asyncio.run(bot.apply_comment(update, context))
+    from telegram.ext import ConversationHandler
+
+    assert res == ConversationHandler.END
+    buttons = captured["markup"].inline_keyboard[0]
+    assert any(b.callback_data == "confirm:1" for b in buttons)
+

--- a/ai_dietolog/tests/test_history_meal_summary.py
+++ b/ai_dietolog/tests/test_history_meal_summary.py
@@ -1,0 +1,64 @@
+import asyncio
+from types import SimpleNamespace
+from datetime import datetime
+
+from ai_dietolog.core import storage
+from ai_dietolog.core.schema import Item, Meal, Today, Total, Profile, HistoryMeal
+from ai_dietolog.bot.handlers import daily_review
+
+
+def test_finish_day_writes_summary(tmp_path, monkeypatch):
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+    user_id = 1
+    meal = Meal(
+        id="1",
+        type="Breakfast",
+        items=[Item(name="apple", kcal=50)],
+        total=Total(kcal=50),
+        pending=False,
+        timestamp=datetime.utcnow(),
+    )
+    storage.save_today(user_id, Today(meals=[meal], summary=Total(kcal=50)))
+
+    monkeypatch.setattr(storage, "load_profile", lambda uid, cls: Profile())
+    monkeypatch.setattr(daily_review, "load_config", lambda: {})
+
+    async def fake_analyze(*args, **kwargs):
+        return ""
+
+    monkeypatch.setattr(daily_review, "analyze_day_summary", fake_analyze)
+
+    class DummyMsg:
+        async def reply_text(self, *a, **k):
+            pass
+
+        async def edit_text(self, *a, **k):
+            pass
+
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=user_id),
+        message=DummyMsg(),
+    )
+    context = SimpleNamespace(user_data={})
+
+    asyncio.run(daily_review.finish_day(update, context))
+
+    class DummyQuery:
+        data = "finish_yes"
+        message = DummyMsg()
+
+        async def answer(self):
+            pass
+
+    asyncio.run(
+        daily_review.confirm_finish_day(
+            SimpleNamespace(callback_query=DummyQuery(), effective_user=SimpleNamespace(id=user_id)),
+            context,
+        )
+    )
+
+    history = storage.read_json(
+        storage.json_path(user_id, "history_meal.json"), HistoryMeal
+    )
+    assert history.days[0].summary.kcal == 50
+


### PR DESCRIPTION
## Summary
- keep confirm button visible after adding a comment to a meal
- record daily nutrient totals in `history_meal.json`
- add tests for comment keyboard and stored day summary

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68984a4071a88324a94953a0adccb8b7